### PR TITLE
Fix TypeError when handling callback for basic.qos

### DIFF
--- a/haigha/classes/basic_class.py
+++ b/haigha/classes/basic_class.py
@@ -53,7 +53,7 @@ class BasicClass(ProtocolClass):
 
     self.channel.add_synchronous_cb( self._recv_qos_ok )
 
-  def _recv_qos_ok(self):
+  def _recv_qos_ok(self, _method_frame):
     # No arguments, nothing to do
     pass
     


### PR DESCRIPTION
`channel.basic.qos(prefetch_count=1)` raises `TypeError` like so:

```
[2011-05-17 16:44:00,378]    ERROR ( 6088) (root / channel): Failed to dispatch MethodFrame[channel: 1, class_id: 60, method_id: 11, args: \x00\x3c\x00\x0b]
Traceback (most recent call last):
  File "/mnt/lib/python2.6/site-packages/haigha/channel.py", line 118, in process_frames
    self.dispatch( frame )
  File "/mnt/lib/python2.6/site-packages/haigha/channel.py", line 97, in dispatch
    klass.dispatch( method_frame )
  File "/mnt/lib/python2.6/site-packages/haigha/classes/protocol_class.py", line 47, in dispatch
    method(method_frame)
TypeError: _recv_qos_ok() takes exactly 1 argument (2 given)
```

This diff fixes the issue.
