### PR TITLE
Enable the AMQP 0.9.1 spec mapping.

### DIFF
--- a/haigha/reader.py
+++ b/haigha/reader.py
@@ -345,40 +345,42 @@ class Reader(object):
 
   # A mapping for quick lookups
   # Rabbit and Qpid 0.9.1 mapping
-  #field_type_map = {
-  #  't' : _field_bool,
-  #  'b' : _field_short_short_int,
-  #  's' : _field_short_int,
-  #  'I' : _field_long_int,
-  #  'l' : _field_long_long_int,
-  #  'f' : _field_float,
-  #  'd' : _field_double,
-  #  'D' : _field_decimal,
-  #  'S' : _field_longstr,
-  #  'T' : _field_timestamp,
-  #  'F' : read_table,
-  #  'V' : _field_none,
-  #  'x' : _field_bytearray,
-  #}
-
-  # 0.9.1 spec mapping
+  # Based on: http://www.rabbitmq.com/amqp-0-9-1-errata.html (3. Field types)
   field_type_map = {
     't' : _field_bool,
     'b' : _field_short_short_int,
-    'B' : _field_short_short_uint,
-    'U' : _field_short_int,
-    'u' : _field_short_uint,
+    's' : _field_short_int,
     'I' : _field_long_int,
-    'i' : _field_long_uint,
-    'L' : _field_long_long_int,
-    'l' : _field_long_long_uint,
+    'l' : _field_long_long_int,
     'f' : _field_float,
     'd' : _field_double,
     'D' : _field_decimal,
-    's' : _field_shortstr,
     'S' : _field_longstr,
     'A' : _field_array,
     'T' : _field_timestamp,
     'F' : read_table,
     'V' : _field_none,
+    'x' : _field_bytearray,
   }
+
+  # 0.9.1 spec mapping
+  #  field_type_map = {
+  #   't' : _field_bool,
+  #   'b' : _field_short_short_int,
+  #   'B' : _field_short_short_uint,
+  #   'U' : _field_short_int,
+  #   'u' : _field_short_uint,
+  #   'I' : _field_long_int,
+  #   'i' : _field_long_uint,
+  #   'L' : _field_long_long_int,
+  #   'l' : _field_long_long_uint,
+  #   'f' : _field_float,
+  #   'd' : _field_double,
+  #   'D' : _field_decimal,
+  #   's' : _field_shortstr,
+  #   'S' : _field_longstr,
+  #   'A' : _field_array,
+  #   'T' : _field_timestamp,
+  #   'F' : read_table,
+  #   'V' : _field_none,
+  #}


### PR DESCRIPTION
This fixes an issue with consuming messages from a federated exchange using RabbitMQ.

This issue can be reproduced by doing the following:
1. Set up a broker with one exchange.
2. Set up a 2nd broker with a federated exchange from broker 1. (http://www.rabbitmq.com/federation.html)
3. Publish a message to exchange on broker 1.
4. Consume a message from exchange on broker 2.
5. The following error occurs:

```
Traceback (most recent call last):
  File "/Users/joey/.virtualenvs/rabbitmq_haigha/lib/python2.7/site-packages/gevent/greenlet.py", line 390, in run
    result = self._run(*self.args, **self.kwargs)
  File "my_haiga_worker.py", line 63, in _message_pump_greenthread
    self._connection.read_frames()
  File "/Users/joey/.virtualenvs/rabbitmq_haigha/lib/python2.7/site-packages/haigha/connection.py", line 346, in read_frames
    for frame in Frame.read_frames( reader ):
  File "/Users/joey/.virtualenvs/rabbitmq_haigha/lib/python2.7/site-packages/haigha/frames/frame.py", line 59, in read_frames
    frame = Frame._read_frame( reader )
  File "/Users/joey/.virtualenvs/rabbitmq_haigha/lib/python2.7/site-packages/haigha/frames/frame.py", line 103, in _read_frame
    return frame_class.parse( channel_id, payload )
  File "/Users/joey/.virtualenvs/rabbitmq_haigha/lib/python2.7/site-packages/haigha/frames/header_frame.py", line 81, in parse
    properties[ key ] = rfunc( payload )
  File "/Users/joey/.virtualenvs/rabbitmq_haigha/lib/python2.7/site-packages/haigha/reader.py", line 228, in read_table
    result[name] = self._read_field()
  File "/Users/joey/.virtualenvs/rabbitmq_haigha/lib/python2.7/site-packages/haigha/reader.py", line 242, in _read_field
    raise Reader.FieldError('Unknown field type %s', ftype)
FormatError: ('Unknown field type %s', 'A')
```
