### PR TITLE
Support field type subclasses

### DIFF
--- a/haigha/tests/unit/reader_test.py
+++ b/haigha/tests/unit/reader_test.py
@@ -324,6 +324,7 @@ class ReaderTest(Chai):
         'd' : Reader._field_double.im_func,
         'D' : Reader._field_decimal.im_func,
         'S' : Reader._field_longstr.im_func,
+        'A' : Reader._field_array.im_func,
         'T' : Reader._field_timestamp.im_func,
         'F' : Reader.read_table.im_func,
         'V' : Reader._field_none.im_func,

--- a/haigha/tests/unit/writer_test.py
+++ b/haigha/tests/unit/writer_test.py
@@ -242,6 +242,12 @@ class WriterTest(Chai):
     w._field_bytearray( bytearray('foo') )
     assert_equals( 'x\x00\x00\x00\x03foo', w._output_buffer )
 
+  def test_write_field_supports_subclasses(self):
+    class SubString(str): pass
+    w = Writer()
+    w._write_field( SubString('foo') )
+    assert_equals( 'S\x00\x00\x00\x03foo', w._output_buffer )
+
   def test_field_iterable(self):
     w = Writer()
     expect( w._write_field ).args('la').side_effect( 
@@ -276,7 +282,7 @@ class WriterTest(Chai):
         unicode   : Writer._field_unicode.im_func,
         datetime  : Writer._field_timestamp.im_func,
         dict      : Writer._field_table.im_func,
-        None      : Writer._field_none.im_func,
+        type(None): Writer._field_none.im_func,
         bytearray : Writer._field_bytearray.im_func,
       }, Writer.field_type_map )
 

--- a/haigha/writer.py
+++ b/haigha/writer.py
@@ -199,8 +199,13 @@ class Writer(object):
     if writer:
       writer(self, value)
     else:
-      # Write a None because we've already written a key
-      self._field_none( value )
+      for kls, writer in self.field_type_map.items():
+        if isinstance(value, kls):
+          writer(self, value)
+          break
+      else:
+        # Write a None because we've already written a key
+        self._field_none( value )
 
   def _field_bool(self, val, pack=Struct('B').pack):
     self._output_buffer.append( 't' )
@@ -274,7 +279,7 @@ class Writer(object):
     unicode   : _field_unicode,
     datetime  : _field_timestamp,
     dict      : _field_table,
-    None      : _field_none,
+    type(None): _field_none,
     bytearray : _field_bytearray,
   }
 


### PR DESCRIPTION
Will write headers if the type of a field is a subclass of the supported native types
