### PR TITLE
Make it possible to specify custom gevent Pool

### DIFF
--- a/haigha/connection.py
+++ b/haigha/connection.py
@@ -124,7 +124,7 @@ class Connection(object):
             elif transport == 'gevent_pool':
                 from haigha.transports.gevent_transport import \
                     GeventPoolTransport
-                self._transport = GeventPoolTransport(self)
+                self._transport = GeventPoolTransport(self, **kwargs)
             elif transport == 'socket':
                 from haigha.transports.socket_transport import SocketTransport
                 self._transport = SocketTransport(self)


### PR DESCRIPTION
To pass gevent pool through `haigha.connection.Connection.__init__` kwargs

As I understand - there is no other way to provide pool size for this kind of transport (except overriding of `Connection` instance `_transport` attribute).
