### PR TITLE
Implemented support and unit tests for handling basic.return

### DIFF
--- a/haigha/classes/basic_class.py
+++ b/haigha/classes/basic_class.py
@@ -76,6 +76,9 @@ class BasicClass(ProtocolClass):
 
         :param cb: callable cb(Message); pass None to reset
         '''
+        if cb is not None and not callable(cb):
+            raise ValueError('return_listener callback must either be None or '
+                             'a callable, but got: %r' % (cb,))
         self._return_listener = cb
 
     def _generate_consumer_tag(self):
@@ -223,7 +226,7 @@ class BasicClass(ProtocolClass):
         '''
         msg = self._read_returned_msg(method_frame)
 
-        if self._return_listener is not None:
+        if callable(self._return_listener):
             self._return_listener(msg)
         else:
             self.logger.error(

--- a/haigha/classes/basic_class.py
+++ b/haigha/classes/basic_class.py
@@ -39,6 +39,7 @@ class BasicClass(ProtocolClass):
         self._get_cb = deque()
         self._recover_cb = deque()
         self._cancel_cb = deque()
+        self._return_listener = None
 
     @property
     def name(self):
@@ -53,7 +54,29 @@ class BasicClass(ProtocolClass):
         self._get_cb = None
         self._recover_cb = None
         self._cancel_cb = None
+        self._return_listener = None
         super(BasicClass, self)._cleanup()
+
+    def set_return_listener(self, cb):
+        '''
+        Set a callback for basic.return listening. Will be called with a single
+        Message argument.
+
+        The return_info attribute of the Message will have the following
+        properties:
+            'channel': Channel instance
+            'reply_code': reply code (int)
+            'reply_text': reply text
+            'exchange': exchange name
+            'routing_key': routing key
+
+        RabbitMQ NOTE: if the channel was in confirmation mode when the message
+        was published, then basic.return will still be followed by basic.ack
+        later.
+
+        :param cb: callable cb(Message); pass None to reset
+        '''
+        self._return_listener = cb
 
     def _generate_consumer_tag(self):
         '''
@@ -189,10 +212,23 @@ class BasicClass(ProtocolClass):
 
         self.send_frame(MethodFrame(self.channel_id, 60, 50, args))
 
-    def _recv_return(self, _method_frame):
-        # This seems like the right place to callback that the operation has
-        # completed.
-        pass
+    def _recv_return(self, method_frame):
+        '''
+        Handle basic.return method. If we have a complete message, will call the
+        user's return listener callabck (if any). If there are not enough
+        frames, will re-queue current frames and raise a FrameUnderflow
+
+        NOTE: if the channel was in confirmation mode when the message was
+        published, then this will still be followed by basic.ack later
+        '''
+        msg = self._read_returned_msg(method_frame)
+
+        if self._return_listener is not None:
+            self._return_listener(msg)
+        else:
+            self.logger.error(
+                "Published message returned by broker: info=%s, properties=%s",
+                msg.return_info, msg.properties)
 
     def _recv_deliver(self, method_frame):
         msg = self._read_msg(method_frame,
@@ -304,26 +340,7 @@ class BasicClass(ProtocolClass):
         FrameUnderflow. Takes an optional argument on whether to read the
         consumer tag so it can be used for both deliver and get-ok.
         '''
-        # No need to assert that is instance of Header or Content frames
-        # because failure to access as such will result in exception that
-        # channel will pick up and handle accordingly.
-        header_frame = self.channel.next_frame()
-        if header_frame:
-            size = header_frame.size
-            body = bytearray()
-            rbuf_frames = deque([header_frame, method_frame])
-
-            while len(body) < size:
-                content_frame = self.channel.next_frame()
-                if content_frame:
-                    rbuf_frames.appendleft(content_frame)
-                    body.extend(content_frame.payload.buffer())
-                else:
-                    self.channel.requeue_frames(rbuf_frames)
-                    raise self.FrameUnderflow()
-        else:
-            self.channel.requeue_frames([method_frame])
-            raise self.FrameUnderflow()
+        header_frame, body = self._reap_msg_frames(method_frame)
 
         if with_consumer_tag:
             consumer_tag = method_frame.args.read_shortstr()
@@ -348,3 +365,63 @@ class BasicClass(ProtocolClass):
 
         return Message(body=body, delivery_info=delivery_info,
                        **header_frame.properties)
+
+    def _read_returned_msg(self, method_frame):
+        '''
+        Support method to read a returned (basic.return) Message from the
+        current frame buffer. Will return a Message with return_info, or
+        re-queue current frames and raise a FrameUnderflow.
+
+        :returns: Message with the return_info attribute set, where return_info
+          is a dict with the following properties:
+            'channel': Channel instance
+            'reply_code': reply code (int)
+            'reply_text': reply text
+            'exchange': exchange name
+            'routing_key': routing key
+        '''
+        header_frame, body = self._reap_msg_frames(method_frame)
+
+        return_info = {
+            'channel': self.channel,
+            'reply_code': method_frame.args.read_short(),
+            'reply_text': method_frame.args.read_shortstr(),
+            'exchange': method_frame.args.read_shortstr(),
+            'routing_key': method_frame.args.read_shortstr()
+        }
+
+        return Message(body=body, return_info=return_info,
+                       **header_frame.properties)
+
+    def _reap_msg_frames(self, method_frame):
+        '''
+        Support method to reap header frame and body from current frame buffer.
+        Used in processing of basic.return, basic.deliver, and basic.get_ok.
+        Will return a pair (<header frame>, <body>), or re-queue current frames
+        and raise a FrameUnderflow.
+
+        :returns: pair (<header frame>, <body>)
+        :rtype: tuple of (HeaderFrame, bytearray)
+        '''
+        # No need to assert that is instance of Header or Content frames
+        # because failure to access as such will result in exception that
+        # channel will pick up and handle accordingly.
+        header_frame = self.channel.next_frame()
+        if header_frame:
+            size = header_frame.size
+            body = bytearray()
+            rbuf_frames = deque([header_frame, method_frame])
+
+            while len(body) < size:
+                content_frame = self.channel.next_frame()
+                if content_frame:
+                    rbuf_frames.appendleft(content_frame)
+                    body.extend(content_frame.payload.buffer())
+                else:
+                    self.channel.requeue_frames(rbuf_frames)
+                    raise self.FrameUnderflow()
+        else:
+            self.channel.requeue_frames([method_frame])
+            raise self.FrameUnderflow()
+
+        return (header_frame, body)

--- a/haigha/message.py
+++ b/haigha/message.py
@@ -11,7 +11,14 @@ class Message(object):
     Represents an AMQP message.
     '''
 
-    def __init__(self, body='', delivery_info=None, **properties):
+    def __init__(self, body='', delivery_info=None, return_info=None,
+                 **properties):
+        '''
+        :param delivery_info: pass only if messages was received via
+          basic.deliver or basic.get_ok; MUST be None otherwise; default: None
+        :param return_info: pass only if message was returned via basic.return;
+          MUST be None otherwise; default: None
+        '''
         if isinstance(body, unicode):
             if 'content_encoding' not in properties:
                 properties['content_encoding'] = 'utf-8'
@@ -22,6 +29,7 @@ class Message(object):
 
         self._body = body
         self._delivery_info = delivery_info
+        self._return_info = return_info
         self._properties = properties
 
     @property
@@ -43,13 +51,31 @@ class Message(object):
 
     @property
     def delivery_info(self):
+        '''delivery_info dict if message was received via basic.deliver or
+        basic.get_ok; None otherwise.
+        '''
         return self._delivery_info
+
+    @property
+    def return_info(self):
+        '''return_info dict if message was returned via basic.return; None
+        otherwise.
+
+        properties:
+            'channel': Channel instance
+            'reply_code': reply code (int)
+            'reply_text': reply text
+            'exchange': exchange name
+            'routing_key': routing key
+        '''
+        return self._return_info
 
     @property
     def properties(self):
         return self._properties
 
     def __str__(self):
-        return "Message[body: %s, delivery_info: %s, properties: %s]" %\
+        return ("Message[body: %s, delivery_info: %s, return_info: %s, "
+                "properties: %s]") %\
             (str(self._body).encode('string_escape'),
-             self._delivery_info, self._properties)
+             self._delivery_info, self.return_info, self._properties)

--- a/tests/unit/classes/basic_class_test.py
+++ b/tests/unit/classes/basic_class_test.py
@@ -64,8 +64,17 @@ class BasicClassTest(Chai):
         assert_equals(None, self.klass._return_listener)
 
     def test_set_return_listener(self):
-        self.klass.set_return_listener('foo')
-        assert_equals('foo', self.klass._return_listener)
+        cb = lambda *args: None
+        self.klass.set_return_listener(cb)
+        assert_is(cb, self.klass._return_listener)
+
+        # Now test resetting it
+        self.klass.set_return_listener(None)
+        assert_is(None, self.klass._return_listener)
+
+    def test_set_invalid_listener_raises_valueerror(self):
+        assert_raises(ValueError, self.klass.set_return_listener, 'foo')
+        assert_is(None, self.klass._return_listener)
 
     def test_generate_consumer_tag(self):
         assert_equals(0, self.klass._consumer_tag_id)

--- a/tests/unit/message_test.py
+++ b/tests/unit/message_test.py
@@ -15,9 +15,10 @@ class MessageTest(Chai):
         m = Message()
         self.assertEquals('', m._body)
         self.assertEquals(None, m._delivery_info)
+        self.assertEquals(None, m.return_info)
         self.assertEquals({}, m._properties)
 
-    def test_init_with_args(self):
+    def test_init_with_delivery_and_args(self):
         m = Message('foo', 'delivery', foo='bar')
         self.assertEquals('foo', m._body)
         self.assertEquals('delivery', m._delivery_info)
@@ -27,10 +28,25 @@ class MessageTest(Chai):
         self.assertEquals('D\xc3\xbcsseldorf', m._body)
         self.assertEquals({'content_encoding': 'utf-8'}, m._properties)
 
-    def test_properties(self):
+    def test_with_body_and_properties(self):
+        m = Message('foo', foo='bar')
+        self.assertEquals('foo', m.body)
+        self.assertEquals(None, m.delivery_info)
+        self.assertEquals(None, m.return_info)
+        self.assertEquals({'foo': 'bar'}, m.properties)
+
+    def test_with_delivery_and_properties(self):
         m = Message('foo', 'delivery', foo='bar')
         self.assertEquals('foo', m.body)
         self.assertEquals('delivery', m.delivery_info)
+        self.assertEquals(None, m.return_info)
+        self.assertEquals({'foo': 'bar'}, m.properties)
+
+    def test_with_return_and_properties(self):
+        m = Message('foo', return_info='return', foo='bar')
+        self.assertEquals('foo', m.body)
+        self.assertEquals('return', m.return_info)
+        self.assertEquals(None, m.delivery_info)
         self.assertEquals({'foo': 'bar'}, m.properties)
 
     def test_len(self):
@@ -76,6 +92,10 @@ class MessageTest(Chai):
 
         self.assertNotEquals(Message(), object())
 
-    def test_str(self):
+    def test_str_with_delivery_info(self):
         m = Message('foo', 'delivery', foo='bar')
+        str(m)
+
+    def test_str_with_return_info(self):
+        m = Message('foo', return_info='returned', foo='bar')
         str(m)


### PR DESCRIPTION
Implemented support and unit tests for handling basic.return, including Message.return_info and BasicClass.set_return_listener()