### PR TITLE
Increase read timeout to twice the heartbeat interval

### DIFF
--- a/haigha/connection.py
+++ b/haigha/connection.py
@@ -404,7 +404,10 @@ class Connection(object):
         # Send a heartbeat (if needed)
         self._channels[0].send_heartbeat()
 
-        data = self._transport.read(self._heartbeat)
+        # Wait for 2 heartbeat intervals before giving up. See AMQP 4.2.7:
+        # "If a peer detects no incoming traffic (i.e. received octets) for two heartbeat intervals or longer,
+        # it should close the connection"
+        data = self._transport.read(self._heartbeat*2)
         if data is None:
             return
 

--- a/haigha/connection.py
+++ b/haigha/connection.py
@@ -415,12 +415,12 @@ class Connection(object):
             # Wait for 2 heartbeat intervals before giving up. See AMQP 4.2.7:
             # "If a peer detects no incoming traffic (i.e. received octets) for two heartbeat intervals or longer,
             # it should close the connection"
-            if self._heartbeat and self._last_octet_time and (current_time-self._last_octet_time > 2*self._heartbeat):
+            if self._heartbeat and (current_time-self._last_octet_time > 2*self._heartbeat):
                 msg = 'Heartbeats not received from %s for %d seconds' % (self._host, 2*self._heartbeat)
                 self.transport_closed(msg=msg)
                 raise ConnectionClosed('Connection is closed: ' + msg)
             return
-        self._last_octet_time = time.time()
+        self._last_octet_time = current_time
         reader = Reader(data)
         p_channels = set()
 


### PR DESCRIPTION
Haigha should wait two heartbeat intervals before giving up on the read request, according to the AMQP 0.9.1 spec. See "4.2.7 - Heartbeat frames":
> If a peer detects no incoming traffic (i.e. received octets) for two heartbeat intervals or longer, it should close the connection without following the Connection.Close/Close-Ok handshaking, and log an error.

@awestendorf, I think that in the future the entire behavior should be changed when this timeout expires. 
According to AMQP, when nothing is read for two heartbeat intervals, the connection should be closed - today, haigha ignores it (returns `None` from `SocketTransport` when it expires).
This causes dead connections to keep on living on client side unnecessarily. 

Tell me if you think this change should not be done. I'm planning additional pull requests to address this soon.

Thanks!