### PR TITLE
[NEED TO DISCUSS] Adds support for RabbitMQ consumer_cancel_notify

### DIFF
--- a/haigha/classes/basic_class.py
+++ b/haigha/classes/basic_class.py
@@ -61,6 +61,8 @@ class BasicClass(ProtocolClass):
 
         The consumer tag is local to a channel, so two clients can use the
         same consumer tags.
+
+        NOTE: this protected method may be called by derived classes
         '''
         self._consumer_tag_id += 1
         return "channel-%d-%d" % (self.channel_id, self._consumer_tag_id)
@@ -122,10 +124,9 @@ class BasicClass(ProtocolClass):
         to only use a consumer once per channel.
         '''
         if consumer:
-            for (tag, func) in self._consumer_cb.iteritems():
-                if func == consumer:
-                    consumer_tag = tag
-                    break
+            tag = self._lookup_consumer_tag_by_consumer(consumer)
+            if tag:
+                consumer_tag = tag
 
         nowait = nowait and self.allow_nowait() and not cb
 
@@ -138,20 +139,41 @@ class BasicClass(ProtocolClass):
             self._cancel_cb.append(cb)
             self.channel.add_synchronous_cb(self._recv_cancel_ok)
         else:
-            try:
-                del self._consumer_cb[consumer_tag]
-            except KeyError:
-                self.logger.warning(
-                    'no callback registered for consumer tag " %s "',
-                    consumer_tag)
+            self._purge_consumer_by_tag(consumer_tag)
 
-    def _recv_cancel_ok(self, method_frame):
-        consumer_tag = method_frame.args.read_shortstr()
+    def _lookup_consumer_tag_by_consumer(self, consumer):
+        '''Look up consumer tag given its consumer function
+
+        NOTE: this protected method may be called by derived classes
+
+        :param callable consumer: consumer function
+
+        :returns: matching consumer tag or None
+        :rtype: str or None
+        '''
+        for (tag, func) in self._consumer_cb.iteritems():
+            if func == consumer:
+                return tag
+
+    def _purge_consumer_by_tag(self, consumer_tag):
+        '''Purge consumer entry from this basic instance
+
+        NOTE: this protected method may be called by derived classes
+
+        :param str consumer_tag:
+        '''
         try:
             del self._consumer_cb[consumer_tag]
         except KeyError:
             self.logger.warning(
                 'no callback registered for consumer tag " %s "', consumer_tag)
+        else:
+            self.logger.info('purged consumer with tag " %s "', consumer_tag)
+
+
+    def _recv_cancel_ok(self, method_frame):
+        consumer_tag = method_frame.args.read_shortstr()
+        self._purge_consumer_by_tag(consumer_tag)
 
         cb = self._cancel_cb.popleft()
         if cb:

--- a/haigha/connections/rabbit_connection.py
+++ b/haigha/connections/rabbit_connection.py
@@ -285,11 +285,11 @@ class RabbitBasicClass(BasicClass):
                 consumer_tag = tag
 
         try:
-            del self._broker_cancel_cb_map[tag]
+            del self._broker_cancel_cb_map[consumer_tag]
         except KeyError:
             self.logger.warning(
                 'cancel: no broker-cancel-cb entry for consumer tag %r '
-                '(consumer %r)', tag, consumer)
+                '(consumer %r)', consumer_tag, consumer)
 
         # Cancel consumer
         super(RabbitBasicClass, self).cancel(*args, **kwargs)

--- a/haigha/connections/rabbit_connection.py
+++ b/haigha/connections/rabbit_connection.py
@@ -258,14 +258,15 @@ class RabbitBasicClass(BasicClass):
             if not callable(cancel_cb):
                 raise ValueError('cancel_cb is not callable: %r' % (cancel_cb,))
 
-        consumer_tag = args[2] if len(args) > 2 else kwargs.get('consumer_tag')
         if not consumer_tag:
             consumer_tag = self._generate_consumer_tag()
 
         self._broker_cancel_cb_map[consumer_tag] = cancel_cb
 
         # Start consumer
-        super(RabbitBasicClass, self).consume(*args, **kwargs)
+        super(RabbitBasicClass, self).consume(queue, consumer, consumer_tag,
+                                              no_local, no_ack, exclusive,
+                                              nowait, ticket, cb)
 
     def cancel(self, consumer_tag='', nowait=True, consumer=None, cb=None):
         '''
@@ -287,7 +288,7 @@ class RabbitBasicClass(BasicClass):
                 '(consumer %r)', consumer_tag, consumer)
 
         # Cancel consumer
-        super(RabbitBasicClass, self).cancel(*args, **kwargs)
+        super(RabbitBasicClass, self).cancel(consumer_tag, nowait, consumer, cb)
 
     def _recv_cancel(self, method_frame):
         '''Handle Basic.Cancel from broker


### PR DESCRIPTION
Hi @awestendorf, it's me again. This PR implements support for RabbitMQ's consumer_cancel_notify feature described in www.rabbitmq.com/consumer-cancel.html. This is a very useful feature that we rely on that prevents consumers from hanging indefinitely when the consumed queue is deleted, for example.

* I am sharing this PR with you early, because I need a tiny bit of help from you with one quick question about coding choices that depend on your preferences. I will enter my question as a comment in this PR in `rabbit_connection.py` near the relevant code.

This PR doesn't have tests yet, so it's not ready for merging.