### PR TITLE
Integration tests

### DIFF
--- a/haigha/message.py
+++ b/haigha/message.py
@@ -49,6 +49,17 @@ class Message(object):
                 self._body == other._body
         return False
 
+    def __getitem__(self, key):
+      if key == 'delivery_info':
+        return self._delivery_info
+      elif key == 'return_info':
+        return self._return_info
+      elif key == 'properties':
+        return self._properties
+      elif key == 'body':
+        return self._body
+      raise AttributeError("No message attribute %s" % key)
+
     @property
     def delivery_info(self):
         '''delivery_info dict if message was received via basic.deliver or

--- a/integration/gevent/test-get.py
+++ b/integration/gevent/test-get.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+from __future__ import print_function
+
+from haigha.connection import Connection
+from haigha.message import Message
+
+import gevent
+from gevent.lock import Semaphore
+
+connection = Connection(
+    user='guest', password='guest',
+    vhost='/', host='localhost',
+    heartbeat=None, debug=False,
+    transport='gevent')
+
+running = True
+frames_read = 0
+msg = None
+
+
+def frame_loop():
+    global frames_read
+    while running:
+        frames_read += connection.read_frames()
+
+
+def basic_get():
+    ch = connection.channel()
+    ch.exchange.declare('test_exchange', 'direct')
+    ch.queue.declare('test_queue', auto_delete=True)
+    ch.queue.bind('test_queue', 'test_exchange', 'test_key')
+    ch.basic.publish(Message('textofbody',
+        application_headers={'hello': 'world'}),
+        'test_exchange', 'test_key')
+    sem = Semaphore()
+
+    def get_cb(m):
+        global msg
+        msg = m
+        sem.release()
+
+    sem.acquire()
+    ch.basic.get('test_queue', consumer=get_cb)
+    sem.wait()
+
+frame_greenlet = gevent.spawn(frame_loop)
+get_greenlet = gevent.spawn(basic_get)
+get_greenlet.join(5)
+connection.close()
+
+# asserts that the gevent frame loop was responsible for reading frames, and
+# it wasn't synchronous behavior in the protocol classes.
+assert(frames_read > 0)
+
+assert(isinstance(msg, Message))
+assert(msg['delivery_info']['exchange'] == 'test_exchange')
+assert(msg['delivery_info']['routing_key'] == 'test_key')
+assert(msg['properties'] ==
+    {'application_headers': {'hello': 'world'}})
+assert(msg['body'] == 'textofbody')
+assert(msg['return_info'] is None)

--- a/integration/synchronous/test-get.py
+++ b/integration/synchronous/test-get.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+from __future__ import print_function
+
+from haigha.connection import Connection
+from haigha.message import Message
+
+connection = Connection(
+    user='guest', password='guest',
+    vhost='/', host='localhost',
+    heartbeat=None, debug=False)
+
+ch = connection.channel()
+ch.exchange.declare('test_exchange', 'direct')
+ch.queue.declare('test_queue', auto_delete=True)
+ch.queue.bind('test_queue', 'test_exchange', 'test_key')
+ch.basic.publish(Message('textofbody', application_headers={'hello': 'world'}),
+    'test_exchange', 'test_key')
+msg = ch.basic.get('test_queue')
+
+ch.queue.unbind('test_queue', 'test_exchange', 'test_key')
+ch.queue.delete('test_queue')
+ch.exchange.delete('test_exchange')
+connection.close()
+
+assert(isinstance(msg, Message))
+assert(msg['delivery_info']['exchange'] == 'test_exchange')
+assert(msg['delivery_info']['routing_key'] == 'test_key')
+assert(msg['properties'] ==
+    {'application_headers': {'hello': 'world'}})
+assert(msg['body'] == 'textofbody')
+assert(msg['return_info'] is None)

--- a/scripts/integration
+++ b/scripts/integration
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for FILE in `find integration/*/test*.py -executable -type f | sort`; do
+  echo $FILE
+  PYTHONPATH=./:$PYTHONPATH ./$FILE
+done


### PR DESCRIPTION
Implements a simple framework for writing integration tests. The purpose is to test features and suites of behaviors against a real AMQP host. This should make it easier to write tests for complex features and bug fixes.

Right now, the "framework" is just a shell script that looks for executable test files in the `integration` directory. In the future, boilerplate may be extracted away so that users have control over the target host, virtual host, passwords and so on.

These tests live outside of the `tests` directory as they can't be run on Travis CI. They can be run from the root project directory by calling `./scripts/integration`