### PR TITLE
Fix #87. Divide the 64bit value by 1e6 in order to be parsed by datetime.fromutctimestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 *.egg-info
 .coverage
+dist/

--- a/haigha/reader.py
+++ b/haigha/reader.py
@@ -231,8 +231,24 @@ class Reader(object):
 
         Will raise BufferUnderflow if there's not enough bytes in the buffer.
         Will raise struct.error if the data is malformed
+
+        To support different RabbitMQ constructs, the timestamp is parsed in different basis from seconds to microseconds.
         """
-        return datetime.utcfromtimestamp(self.read_longlong() / 1e6)
+        ts = self.read_longlong()
+        try:
+            # Try to parse the timestamp in seconds
+            return datetime.utcfromtimestamp(ts)
+        except:
+            try:
+                # Try to parse the timestamp in milliseconds
+                return datetime.utcfromtimestamp(ts / 1e3)
+            except:
+                try:
+                    # Try to parse the timestamp in microseconds
+                    return datetime.utcfromtimestamp(ts / 1e6)
+                except:
+                    # Failed to parse the timestamp
+                    raise
 
     def read_table(self):
         """

--- a/haigha/reader.py
+++ b/haigha/reader.py
@@ -232,7 +232,7 @@ class Reader(object):
         Will raise BufferUnderflow if there's not enough bytes in the buffer.
         Will raise struct.error if the data is malformed
         """
-        return datetime.utcfromtimestamp(self.read_longlong())
+        return datetime.utcfromtimestamp(self.read_longlong() / 1e6)
 
     def read_table(self):
         """

--- a/haigha/reader.py
+++ b/haigha/reader.py
@@ -238,15 +238,15 @@ class Reader(object):
         try:
             # Try to parse the timestamp in seconds
             return datetime.utcfromtimestamp(ts)
-        except:
+        except ValueError:
             try:
                 # Try to parse the timestamp in milliseconds
                 return datetime.utcfromtimestamp(ts / 1e3)
-            except:
+            except ValueError:
                 try:
                     # Try to parse the timestamp in microseconds
                     return datetime.utcfromtimestamp(ts / 1e6)
-                except:
+                except ValueError:
                     # Failed to parse the timestamp
                     raise
 


### PR DESCRIPTION
Related to https://github.com/agoragames/haigha/issues/87