### PR TITLE
Install gevent when running on travis, so that gevent transport tests will run, too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 script: nosetests
 install:
   - "pip install -r development.txt"
+  - "if [ ${TRAVIS_PYTHON_VERSION} != 'pypy' ]; then pip install gevent; fi"
   - "pip install nose"
 services:
   - rabbitmq


### PR DESCRIPTION
@awestendorf, I noticed that gevent transport tests weren't running on Travis, so I submitted this PR to make sure those tests run. The stock gevent doesn't build on pypy at the moment, so the gevent is installed only on the non pypy python versions.