### PR TITLE
Don't print exceptions for each connection on windows machines

### DIFF
--- a/haigha/transports/socket_transport.py
+++ b/haigha/transports/socket_transport.py
@@ -49,7 +49,7 @@ class SocketTransport(Transport):
 
             except socket.error:
 
-                self.connection.logger.exception(
+                self.connection.logger.warning(
                     "Failed to connect to %s:",
                     sockaddr,
                 )


### PR DESCRIPTION
On windows machines the socket always fails to connect ::1 (IPv6 localhost format).
socket_transport.connect.54: Failed to connect to ('::1', 5672, 0, 0):
`Traceback (most recent call last):
  File "C:\Python27\lib\site-packages\haigha\transports\socket_transport.py", line 48, in connect
    self._sock.connect(sockaddr)
  File "C:\Python27\lib\site-packages\gevent\_socket2.py", line 228, in connect
    raise error(err, strerror(err))
error: [Errno 10061] [Error 10061] No connection could be made because the target machine actively refused it.`

As we are throwing an exception at the end of the loop, I believe that single failures should be logged only as a warning.
